### PR TITLE
pairReaches function

### DIFF
--- a/R/pairReaches.R
+++ b/R/pairReaches.R
@@ -21,7 +21,15 @@
 pairReaches <- function(hierarchy, site1, site2) {
     sites <- c(site1, site2)
     all.ds.sites <- list_all_downstream(hierarchy, sites)
-    ds.sites <- unique(c(setdiff(all.ds.sites[[1]], all.ds.sites[[2]]), setdiff(all.ds.sites[[2]], all.ds.sites[[1]])))
-    ds.sites <- unique(c(ds.sites, site1, site2))
-    return(ds.sites)
+    
+    # check if the two sites can be linked within stream network.
+    if(length(intersect(all.ds.sites[[1]],all.ds.sites[[2]]))>1){
+      ds.sites <- unique(c(setdiff(all.ds.sites[[1]], all.ds.sites[[2]]), setdiff(all.ds.sites[[2]], all.ds.sites[[1]])))
+      ds.sites <- unique(c(ds.sites, site1, site2))
+      return(ds.sites)
+    }
+    else{
+      cat("the two sites can be linked within stream network.\n")
+      return(NA)
+    }
 }

--- a/R/pairReaches.R
+++ b/R/pairReaches.R
@@ -22,14 +22,14 @@ pairReaches <- function(hierarchy, site1, site2) {
     sites <- c(site1, site2)
     all.ds.sites <- list_all_downstream(hierarchy, sites)
     
-    # check if the two sites can be linked within stream network.
+    # check if the two sites are within the same stream network.
     if(length(intersect(all.ds.sites[[1]],all.ds.sites[[2]]))>1){
       ds.sites <- unique(c(setdiff(all.ds.sites[[1]], all.ds.sites[[2]]), setdiff(all.ds.sites[[2]], all.ds.sites[[1]])))
       ds.sites <- unique(c(ds.sites, site1, site2))
       return(ds.sites)
     }
     else{
-      cat("the two sites can be linked within stream network.\n")
+      cat("the two sites are from different stream networks.\n")
       return(NA)
     }
 }


### PR DESCRIPTION
Hi Nick,
I found the current pairReaches function could return unrealistic results for two sites from different river networks. I thus suggest adding a check of whether the two provided sites are from the same river network before this function proceeds for calculation.
Cheers,
Sunny
