### PR TITLE
modify extractRasterPoly with velox package

### DIFF
--- a/R/extractRasterPoly.R
+++ b/R/extractRasterPoly.R
@@ -27,19 +27,26 @@
 
 extractRasterPoly <- function(shpfile, rast, catid_col, start = 1, end = nrow(shpfile)) {
 
-    # vector('list', length(start:end))
-
-    loc.values <- vector("list", length(start:end))
-    shpfile <- shpfile[start:end, ]
-
-    for (i in 1:length(shpfile)) {
-        poly <- shpfile[i, ]
-        loc.values[[i]] <- raster::extract(rast, poly, na.rm = T, weights = TRUE, fun = "mean", normalizeWeights = TRUE, small = TRUE)
-        print(i)
-    }
-
-    loc.values.df <- as.data.frame(t(do.call("rbind", loc.values)))
-    names(loc.values.df) <- shpfile@data[, catid_col]
-    return(loc.values.df)
+  # vector('list', length(start:end))
+  
+  #loc.values <- vector("list", length(start:end))
+  shpfile <- shpfile[start:end, ]
+  
+  #for (i in 1:length(shpfile)) {
+  #  poly <- shpfile[i, ]
+  #  loc.values[[i]] <- raster::extract(rast, poly, na.rm = T, weights = TRUE, fun = "mean", normalizeWeights = TRUE, small = TRUE)
+  #  print(i)
+  #}
+  #
+  #loc.values.df <- as.data.frame(t(do.call("rbind", loc.values)))
+  
+  rast<-velox(rast)   # require the "velox" R package
+  loc.values.df<-rast$extract(shpfile,fun=mean, small=TRUE,df=TRUE)
+  
+  loc.values.df[is.na(loc.values.df)]<-0
+  rownames(loc.values.df) <- shpfile@data[, catid_col]
+  loc.values.df<-t(loc.values.df)
+  return(loc.values.df[-1,])
+    
 }
 

--- a/R/extractRasterPoly.R
+++ b/R/extractRasterPoly.R
@@ -1,4 +1,5 @@
 #' function to extract data from a raster or raster stack for indivdiual polygons within a shapefile.
+#' require "velox" package
 #'
 #' @param shpfile The shapefile to be used to intersect with the raster layers
 #' @param rast The raster layer(s) to be intersected


### PR DESCRIPTION
Hi Nick,

I modified the extractRasterPoly function with the velox package by replacing raster::extract with velox::extract, which is much faster (>10 times).

The results from the modified version is the almost the same as those from the previous version (only the rownames of the returned data frame are different).

I prepared a script for you to have a quick look into the comparison between the two versions. I will send to you the script as well as supporting data via email.

Hope that helps.

Cheers,
Sunny